### PR TITLE
Added .local/bin to path after installing twine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
           command: |
             set -o nounset
             pip install --user twine
+            PATH=/home/circleci/.local/bin:$PATH
             twine upload -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} dist/*
 
 workflows:


### PR DESCRIPTION
I tested this by connecting to the circleci VM and than this step wasn't required.
But apparantly now it is