### PR TITLE
Use list for compose_files instead of map

### DIFF
--- a/src/pytest_docker_compose/__init__.py
+++ b/src/pytest_docker_compose/__init__.py
@@ -126,7 +126,7 @@ class DockerComposePlugin:
             project_dir = '.'
 
         # py35 needs strings for os.path functions
-        compose_files = map(str, compose_files)
+        compose_files = [str(p) for p in compose_files]
 
         project = project_from_options(
             project_dir=str(project_dir),

--- a/src/pytest_docker_compose/__init__.py
+++ b/src/pytest_docker_compose/__init__.py
@@ -126,6 +126,8 @@ class DockerComposePlugin:
             project_dir = '.'
 
         # py35 needs strings for os.path functions
+        # Must be a list; will get accessed multiple times.
+        # https://github.com/pytest-docker-compose/pytest-docker-compose/pull/72
         compose_files = [str(p) for p in compose_files]
 
         project = project_from_options(

--- a/tests/pytest_docker_compose_tests/test_single_compose_file.py
+++ b/tests/pytest_docker_compose_tests/test_single_compose_file.py
@@ -1,0 +1,44 @@
+import time
+import requests
+from urllib.parse import urljoin
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
+
+import pytest
+
+pytest_plugins = ["docker_compose"]
+
+
+@pytest.fixture(scope="module")
+def wait_for_api(module_scoped_container_getter):
+    """Wait for the api from my_api_service to become responsive"""
+    request_session = requests.Session()
+    retries = Retry(total=5,
+                    backoff_factor=0.1,
+                    status_forcelist=[500, 502, 503, 504])
+    request_session.mount('http://', HTTPAdapter(max_retries=retries))
+
+    service = module_scoped_container_getter.get("my_api_service").network_info[0]
+    api_url = "http://%s:%s/" % (service.hostname, service.host_port)
+    assert request_session.get(api_url)
+
+    start = time.time()
+    while 'Exit' not in module_scoped_container_getter.get("my_short_lived_service").human_readable_state:
+        if time.time() - start >= 5:
+            raise RuntimeError(
+                'my_short_lived_service should spin up, echo "Echoing" and '
+                'then shut down, since it still running something went wrong'
+            )
+        time.sleep(.5)
+
+    return request_session, api_url
+
+
+@pytest.mark.compose_file_path
+def test_read_all(wait_for_api):
+    request_session, api_url = wait_for_api
+    assert len(request_session.get(urljoin(api_url, 'items/all')).json()) == 0
+
+
+if __name__ == '__main__':
+    pytest.main(['-m', 'compose_file_path', '--docker-compose', './my_network/docker-compose.yml', '--docker-compose-no-build'])


### PR DESCRIPTION
Was trying out pytest-docker-compose, have to have a custom path for my docker-compose file in my use case, and it didn't seem like the path I gave was actually getting used. It seems it has to do with how the `compose_files` variable is handled.

`compose_files` holds the list of docker-compose file paths gets transformed into a map of strings prior to passing it to `project_from_options()`. However, `project_from_options()` ends up accessing the iterator twice, which results in an empty list on the second read due to the variable being a map:

```
def project_from_options(project_dir, options, additional_options=None):
    override_dir = get_project_dir(options) ### Runs get_config_path_from_options under the hood
    return get_project(
        project_dir,
        get_config_path_from_options(options, environment) ### This arg will always be [] instead of the `compose_files` values
```